### PR TITLE
Basic Wix source file to create MSI

### DIFF
--- a/developer_notes.txt
+++ b/developer_notes.txt
@@ -6,4 +6,4 @@
 
 heat dir deps\salt -gg -cg PortableSalt -var var.SaltDir -sreg -o allfiles.wxs
 candle -dSaltDir="deps\salt" salt_x86.wxs allfiles.wxs
-light salt.wixobj allfiles.wixobj -o salt_x86.msi
+light salt_x86.wixobj allfiles.wixobj -o salt_x86.msi

--- a/developer_notes.txt
+++ b/developer_notes.txt
@@ -1,0 +1,9 @@
+- The installer use the PortablePython distribution as the base
+
+- Download Wix 3.5 from http://wix.codeplex.com/
+- Append "C:\Program Files\Windows Installer XML v3.5\bin" to PATH environment variable
+- Run these three commands to create MSI.
+
+heat dir deps\salt -gg -cg PortableSalt -var var.SaltDir -sreg -o allfiles.wxs
+candle -dSaltDir="deps\salt" salt_x86.wxs allfiles.wxs
+light salt.wixobj allfiles.wixobj -o salt_x86.msi

--- a/salt_x86.wxs
+++ b/salt_x86.wxs
@@ -52,6 +52,13 @@
         Permanent="no" System="yes" Value="[TARGETDIR]salt\minion" />
     </Component>
 
+    <Component Id="OPENSSL_PATH_ENV"
+      Guid="{25AEB8E7-3774-4403-828E-C5A3B59B9D64}">
+      <Environment Id="OPENSSL_PATH" Action="set" Part="last"
+        Name="PATH"
+        Permanent="no" System="yes" Value="[TARGETDIR]salt\OpenSSL-Win32\bin" />
+    </Component>
+
   </Directory>
 
   <!--
@@ -70,6 +77,7 @@
   <Feature Id='Salt' Title='Python with all packages' Level='1'>
     <ComponentGroupRef Id="PortableSalt" />
     <ComponentRef Id="MINION_CONFIG_ENV" />
+    <ComponentRef Id="OPENSSL_PATH_ENV" />
     <!--
     <ComponentRef Id="python27_dll" />
     <ComponentRef Id="pythoncom27_dll" />

--- a/salt_x86.wxs
+++ b/salt_x86.wxs
@@ -1,0 +1,82 @@
+<?xml version='1.0'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+<Product
+    Id='{29AEB8E7-3773-4403-828E-C5A3B59B9D62}'
+    Name='Salt'
+    Language='1033'
+    Version='1.0.0.1'
+    Manufacturer='Salt Community'
+    UpgradeCode='{29AEB8E7-3773-4403-828E-C5A3B59B9D63}'>
+  <Package
+    Description='Salt Windows Installer package'
+    Comments='Salt Windows Installer with all dependencies'
+    Manufacturer='Salt Community'
+    InstallerVersion='200'
+    Compressed='yes' />
+
+  <Media Id='1' Cabinet='salt.cab' EmbedCab='yes' />
+
+  <Directory Id='TARGETDIR' Name='SourceDir'>
+
+    <!--
+    <Directory Id='WINDOWSDir' Name='WINDOWS'>
+      <Directory Id='System32Dir' Name='System32'>
+        <Component Id='python27_dll'
+          Guid='{24AEB8E6-3773-4401-828E-C5A3B59B9D64}'>
+          <File Id='PYTHON27.DLL' Name='python27.dll'
+	    DiskId='1' Source='deps\salt\python\App\python27.dll' />
+        </Component>
+        <Component Id='pythoncom27_dll'
+          Guid='{24AEB8E6-3773-4402-828E-C5A3B59B9D64}'>
+          <File Id='PYTHONCOM27.DLL' Name='pythoncom27.dll'
+	    DiskId='1' Source='deps\salt\python\App\pythoncom27.dll' />
+        </Component>
+        <Component Id='pythoncomloader27_dll'
+          Guid='{24AEB8E6-3773-4403-828E-C5A3B59B9D64}'>
+          <File Id='PYTHONCOMLOADER27.DLL' Name='pythoncomloader27.dll'
+	    DiskId='1' Source='deps\salt\python\App\pythoncomloader27.dll' />
+        </Component>
+        <Component Id='pywintypes27_dll'
+          Guid='{24AEB8E6-3773-4404-828E-C5A3B59B9D64}'>
+          <File Id='PYWINTYPES27.DLL' Name='pywintypes27.dll'
+	    DiskId='1' Source='deps\salt\python\App\pywintypes27.dll' />
+        </Component>
+      </Directory>
+    </Directory>
+    -->
+
+    <Component Id="MINION_CONFIG_ENV"
+      Guid="{25AEB8E7-3773-4403-828E-C5A3B59B9D64}">
+      <Environment Id="SALT_MINION_CONFIG" Action="set" Part="all"
+        Name="SALT_MINION_CONFIG" 
+        Permanent="no" System="yes" Value="[TARGETDIR]salt\minion" />
+    </Component>
+
+  </Directory>
+
+  <!--
+  <Binary Id='vcredist_exe' SourceFile='deps\win32-py2.7\vcredist_x86.exe' />
+
+  <CustomAction Id="Installvcredist"
+    BinaryKey="vcredist_exe"
+    ExeCommand='vcredist_x86.exe'
+    Execute="immediate"
+    Return="ignore" />
+
+  <InstallExecuteSequence>
+    <Custom Action="Installvcredist" After="InstallInitialize"/>
+  </InstallExecuteSequence>
+  -->
+  <Feature Id='Salt' Title='Python with all packages' Level='1'>
+    <ComponentGroupRef Id="PortableSalt" />
+    <ComponentRef Id="MINION_CONFIG_ENV" />
+    <!--
+    <ComponentRef Id="python27_dll" />
+    <ComponentRef Id="pythoncom27_dll" />
+    <ComponentRef Id="pythoncomloader27_dll" />
+    <ComponentRef Id="pywintypes27_dll" />
+    -->
+  </Feature>
+
+</Product>
+</Wix>

--- a/salt_x86.wxs
+++ b/salt_x86.wxs
@@ -44,7 +44,7 @@
       <Environment Id="OPENSSL_CONF" Action="set" Part="all"
         Name="OPENSSL_CONF"
         Permanent="no" System="yes"
-	Value="[TARGETDIR]salt\OpenSSL-Win32\bin\openssl.cfg" />
+        Value="[TARGETDIR]salt\OpenSSL-Win32\bin\openssl.cfg" />
     </Component>
 
   </Directory>

--- a/salt_x86.wxs
+++ b/salt_x86.wxs
@@ -53,10 +53,18 @@
     </Component>
 
     <Component Id="OPENSSL_PATH_ENV"
-      Guid="{25AEB8E7-3774-4403-828E-C5A3B59B9D64}">
+      Guid="{25AEB8E8-3774-4403-828E-C5A3B59B9D64}">
       <Environment Id="OPENSSL_PATH" Action="set" Part="last"
         Name="PATH"
         Permanent="no" System="yes" Value="[TARGETDIR]salt\OpenSSL-Win32\bin" />
+    </Component>
+
+    <Component Id="OPENSSL_CONF_ENV"
+      Guid="{25AEB8E7-3774-4403-828E-C5A3B59B9D64}">
+      <Environment Id="OPENSSL_CONF" Action="set" Part="all"
+        Name="OPENSSL_CONF"
+        Permanent="no" System="yes"
+	Value="[TARGETDIR]salt\OpenSSL-Win32\bin\openssl.cfg" />
     </Component>
 
   </Directory>
@@ -78,6 +86,7 @@
     <ComponentGroupRef Id="PortableSalt" />
     <ComponentRef Id="MINION_CONFIG_ENV" />
     <ComponentRef Id="OPENSSL_PATH_ENV" />
+    <ComponentRef Id="OPENSSL_CONF_ENV" />
     <!--
     <ComponentRef Id="python27_dll" />
     <ComponentRef Id="pythoncom27_dll" />

--- a/salt_x86.wxs
+++ b/salt_x86.wxs
@@ -18,33 +18,6 @@
 
   <Directory Id='TARGETDIR' Name='SourceDir'>
 
-    <!--
-    <Directory Id='WINDOWSDir' Name='WINDOWS'>
-      <Directory Id='System32Dir' Name='System32'>
-        <Component Id='python27_dll'
-          Guid='{24AEB8E6-3773-4401-828E-C5A3B59B9D64}'>
-          <File Id='PYTHON27.DLL' Name='python27.dll'
-	    DiskId='1' Source='deps\salt\python\App\python27.dll' />
-        </Component>
-        <Component Id='pythoncom27_dll'
-          Guid='{24AEB8E6-3773-4402-828E-C5A3B59B9D64}'>
-          <File Id='PYTHONCOM27.DLL' Name='pythoncom27.dll'
-	    DiskId='1' Source='deps\salt\python\App\pythoncom27.dll' />
-        </Component>
-        <Component Id='pythoncomloader27_dll'
-          Guid='{24AEB8E6-3773-4403-828E-C5A3B59B9D64}'>
-          <File Id='PYTHONCOMLOADER27.DLL' Name='pythoncomloader27.dll'
-	    DiskId='1' Source='deps\salt\python\App\pythoncomloader27.dll' />
-        </Component>
-        <Component Id='pywintypes27_dll'
-          Guid='{24AEB8E6-3773-4404-828E-C5A3B59B9D64}'>
-          <File Id='PYWINTYPES27.DLL' Name='pywintypes27.dll'
-	    DiskId='1' Source='deps\salt\python\App\pywintypes27.dll' />
-        </Component>
-      </Directory>
-    </Directory>
-    -->
-
     <Component Id="MINION_CONFIG_ENV"
       Guid="{25AEB8E7-3773-4403-828E-C5A3B59B9D64}">
       <Environment Id="SALT_MINION_CONFIG" Action="set" Part="all"
@@ -89,18 +62,13 @@
     <Custom Action="Installvcredist" After="InstallInitialize"/>
   </InstallExecuteSequence>
   -->
+
   <Feature Id='Salt' Title='Python with all packages' Level='1'>
     <ComponentGroupRef Id="PortableSalt" />
     <ComponentRef Id="MINION_CONFIG_ENV" />
     <ComponentRef Id="OPENSSL_PATH_ENV" />
     <ComponentRef Id="PYWIN32_PATH_ENV" />
     <ComponentRef Id="OPENSSL_CONF_ENV" />
-    <!--
-    <ComponentRef Id="python27_dll" />
-    <ComponentRef Id="pythoncom27_dll" />
-    <ComponentRef Id="pythoncomloader27_dll" />
-    <ComponentRef Id="pywintypes27_dll" />
-    -->
   </Feature>
 
 </Product>

--- a/salt_x86.wxs
+++ b/salt_x86.wxs
@@ -49,7 +49,7 @@
       Guid="{25AEB8E7-3773-4403-828E-C5A3B59B9D64}">
       <Environment Id="SALT_MINION_CONFIG" Action="set" Part="all"
         Name="SALT_MINION_CONFIG" 
-        Permanent="no" System="yes" Value="[TARGETDIR]salt\minion" />
+        Permanent="no" System="yes" Value="[TARGETDIR]salt\etc\salt\minion" />
     </Component>
 
     <Component Id="OPENSSL_PATH_ENV"
@@ -57,6 +57,13 @@
       <Environment Id="OPENSSL_PATH" Action="set" Part="last"
         Name="PATH"
         Permanent="no" System="yes" Value="[TARGETDIR]salt\OpenSSL-Win32\bin" />
+    </Component>
+
+    <Component Id="PYWIN32_PATH_ENV"
+      Guid="{25AEB8E9-3774-4403-828E-C5A3B59B9D64}">
+      <Environment Id="PYWIN32_PATH" Action="set" Part="last"
+        Name="PATH"
+        Permanent="no" System="yes" Value="[TARGETDIR]salt\python\App" />
     </Component>
 
     <Component Id="OPENSSL_CONF_ENV"
@@ -86,6 +93,7 @@
     <ComponentGroupRef Id="PortableSalt" />
     <ComponentRef Id="MINION_CONFIG_ENV" />
     <ComponentRef Id="OPENSSL_PATH_ENV" />
+    <ComponentRef Id="PYWIN32_PATH_ENV" />
     <ComponentRef Id="OPENSSL_CONF_ENV" />
     <!--
     <ComponentRef Id="python27_dll" />


### PR DESCRIPTION
Steps to create MSI:
- Download Wix 3.5 from http://wix.codeplex.com/
- Append "C:\Program Files\Windows Installer XML v3.5\bin" to PATH environment variable
- Run these three commands to create MSI.
  
  heat dir deps\salt -gg -cg PortableSalt -var var.SaltDir -sreg -o allfiles.wxs
  candle -dSaltDir="deps\salt" salt_x86.wxs allfiles.wxs
  light salt_x86.wixobj allfiles.wixobj -o salt_x86.msi

This gives a minimal installer, without vcredist_x86.exe
The Win32OpenSSL is included as per the instruction, but seems to be not working.
So, if both vcredist & Win32OpenSSL is installed before this, Salt minion should run.

I have added instruction for running vcredist_x86.exe, but it's commented, it makes
the installer crash in my system.

I hope this would be a good start, we can tweak it as we progress.
