### PR TITLE
Installing another MSI within MSI will not work

### DIFF
--- a/salt_x86.wxs
+++ b/salt_x86.wxs
@@ -49,20 +49,6 @@
 
   </Directory>
 
-  <!--
-  <Binary Id='vcredist_exe' SourceFile='deps\win32-py2.7\vcredist_x86.exe' />
-
-  <CustomAction Id="Installvcredist"
-    BinaryKey="vcredist_exe"
-    ExeCommand='vcredist_x86.exe'
-    Execute="immediate"
-    Return="ignore" />
-
-  <InstallExecuteSequence>
-    <Custom Action="Installvcredist" After="InstallInitialize"/>
-  </InstallExecuteSequence>
-  -->
-
   <Feature Id='Salt' Title='Python with all packages' Level='1'>
     <ComponentGroupRef Id="PortableSalt" />
     <ComponentRef Id="MINION_CONFIG_ENV" />


### PR DESCRIPTION
Removed the vcredist related tables.  This approach
is not going to work.  An MSI cannot call another
MSI while the previous one is running.  In fact,
the vcredist_86.exe embed another MSI.
So, we need to create an EXE using some other
installer or write native C# code to create EXE.
This EXE can call vcredist, Win32OpenSSL & Salt MSI
files.  For now, we can ship three files and provide
documentation for installation.  Later, we can create
wrapper EXE using NSIS :-)
